### PR TITLE
Codespace legendary dollop gp5rx6prggg266v

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,16 @@
 	"ct3aMetadata": {
 		"initVersion": "7.39.3"
 	},
-	"packageManager": "pnpm@10.6.4"
+	"packageManager": "pnpm@10.6.4",
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"@prisma/client",
+			"@prisma/engines",
+			"@tailwindcss/oxide",
+			"esbuild",
+			"prisma",
+			"sharp"
+		]
+	}
 }

--- a/src/app/(dashboard)/_components/teamSidebar.tsx
+++ b/src/app/(dashboard)/_components/teamSidebar.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 
 import Link from "next/link";
-import Image from "next/image";
 import { Poppins } from "next/font/google";
 import { cn } from "~/app/_lib/utils";
 import { FaSnowman } from "react-icons/fa";
@@ -27,7 +26,9 @@ function TeamSidebar() {
 					NordBoard
 				</span>
 			</Link>
-			<TeamSwitchDropdown />
+			<div className="flex w-[90%] flex-col space-x-2">
+				<TeamSwitchDropdown />
+			</div>
 		</div>
 	);
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -9,6 +9,7 @@ import TeamSidebar from "./_components/teamSidebar";
 import Navbar from "./_components/navbar";
 import { TeamProvider } from "../_lib/teamContext";
 import { S3Provider } from "../_lib/s3Context";
+import { SessionProvider } from "next-auth/react";
 
 export const metadata: Metadata = {
 	title: "Create T3 App",
@@ -25,21 +26,23 @@ export default function RootLayout({
 	children,
 }: Readonly<{ children: React.ReactNode }>) {
 	return (
-		<TeamProvider>
-			<S3Provider>
-				<main className="h-[100vh]">
-					<Sidebar />
-					<div className="h-full pl-[60px]">
-						<div className="flex h-full gap-x-3">
-							<TeamSidebar />
-							<div className="h-full flex-1">
-								<Navbar />
-								{children}
+		<SessionProvider>
+			<TeamProvider>
+				<S3Provider>
+					<main className="h-[100vh]">
+						<Sidebar />
+						<div className="h-full pl-[60px]">
+							<div className="flex h-full gap-x-3">
+								<TeamSidebar />
+								<div className="h-full flex-1">
+									<Navbar />
+									{children}
+								</div>
 							</div>
 						</div>
-					</div>
-				</main>
-			</S3Provider>
-		</TeamProvider>
+					</main>
+				</S3Provider>
+			</TeamProvider>
+		</SessionProvider>
 	);
 }

--- a/src/app/_components/teams/newTeamForm.tsx
+++ b/src/app/_components/teams/newTeamForm.tsx
@@ -24,13 +24,21 @@ import { api } from "~/trpc/react";
 // File Size Limit 10MB
 
 const formSchema = z.object({
-	name: z.string().min(2, {
-		message: "Team name must be at least 2 characters.",
-	}),
+	name: z
+		.string()
+		.min(2, {
+			message: "Team name must be at least 2 characters.",
+		})
+		.max(16, {
+			message: "Team name cannot exceed 16 characters.",
+		}),
 	slug: z
 		.string()
 		.min(2, {
 			message: "Team slug must be at least 2 characters.",
+		})
+		.max(16, {
+			message: "Team slug cannot exceed 16 characters.",
 		})
 		.regex(/^[a-z0-9-]+$/, {
 			message:

--- a/src/app/_components/teams/teamSwitchDropdown.tsx
+++ b/src/app/_components/teams/teamSwitchDropdown.tsx
@@ -1,64 +1,183 @@
+// "use client";
+// import type React from "react";
+// import {
+// 	Select,
+// 	SelectContent,
+// 	SelectItem,
+// 	SelectTrigger,
+// 	SelectValue,
+// } from "../ui/select";
+// import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+// import { useTeams } from "~/app/_lib/teamContext";
+// import { useS3 } from "~/app/_lib/s3Context";
+// import { useParams, useRouter } from "next/navigation";
+
+// function TeamSwitchDropdown({ children, ...props }: React.PropsWithChildren) {
+// 	const params = useParams();
+// 	const router = useRouter();
+
+// 	const teamSlug = params?.teamSlug as string;
+
+// 	const { teams } = useTeams();
+// 	const { icons } = useS3();
+
+// 	if (!teams) {
+// 		return null;
+// 	}
+
+// 	const teamsContent = teams.map((team) => (
+// 		<SelectItem key={team.id} value={team.uniqueId}>
+// 			<Avatar>
+// 				{team.icon ? (
+// 					<AvatarImage
+// 						src={icons?.find((t) => t.key === team.icon)?.url ?? undefined}
+// 					/>
+// 				) : (
+// 					<AvatarFallback>
+// 						{team.name
+// 							.split(" ")
+// 							.map((word) => word[0])
+// 							.join("")
+// 							.toUpperCase()}
+// 					</AvatarFallback>
+// 				)}
+// 			</Avatar>
+// 			{team.name}
+// 		</SelectItem>
+// 	));
+
+// 	const onChange = (value: string) => {
+// 		if (value !== teamSlug) {
+// 			router.push(`/${value}`);
+// 		}
+// 	};
+
+// 	return (
+// 		<Select {...props} value={teamSlug ?? undefined} onValueChange={onChange}>
+// 			<SelectTrigger className="w-full">
+// 				<SelectValue placeholder="Select a team" />
+// 			</SelectTrigger>
+// 			<SelectContent className="w-full">{teamsContent}</SelectContent>
+// 		</Select>
+// 	);
+// }
+
+// export default TeamSwitchDropdown;
+
 "use client";
-import type React from "react";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "../ui/select";
-import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
-import { useTeams } from "~/app/_lib/teamContext";
+import React from "react";
 import { useS3 } from "~/app/_lib/s3Context";
-import { useParams, useRouter } from "next/navigation";
+import { useTeams } from "~/app/_lib/teamContext";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { Button } from "../ui/button";
+import { useParams } from "next/navigation";
+import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+import { ChevronsUpDown, Plus, Settings } from "lucide-react";
+import { Card, CardHeader, CardTitle } from "../ui/card";
+import { DropdownMenuLabel } from "@radix-ui/react-dropdown-menu";
+import { useSession } from "next-auth/react";
+import { Badge } from "../ui/badge";
 
-function TeamSwitchDropdown({ children, ...props }: React.PropsWithChildren) {
-	const params = useParams();
-	const router = useRouter();
-
-	const teamSlug = params?.teamSlug as string;
-
+function TeamSwitchDropdown() {
 	const { teams } = useTeams();
 	const { icons } = useS3();
+	const session = useSession();
 
-	if (!teams) {
-		return null;
-	}
+	const params = useParams();
+	const teamSlug = params?.teamSlug as string;
+	const currentTeam = teams?.find((team) => team.uniqueId === teamSlug);
+	const currentTeamIcon = icons?.find((t) => t.key === currentTeam?.icon)?.url;
 
-	const teamsContent = teams.map((team) => (
-		<SelectItem key={team.id} value={team.uniqueId}>
-			<Avatar>
-				{team.icon ? (
-					<AvatarImage
-						src={icons?.find((t) => t.key === team.icon)?.url ?? undefined}
-					/>
-				) : (
-					<AvatarFallback>
-						{team.name
-							.split(" ")
-							.map((word) => word[0])
-							.join("")
-							.toUpperCase()}
-					</AvatarFallback>
-				)}
-			</Avatar>
-			{team.name}
-		</SelectItem>
-	));
-
-	const onChange = (value: string) => {
-		if (value !== teamSlug) {
-			router.push(`/${value}`);
-		}
-	};
+	const onTeamSelect = (value: string) => {};
 
 	return (
-		<Select {...props} value={teamSlug ?? undefined} onValueChange={onChange}>
-			<SelectTrigger>
-				<SelectValue placeholder="Select a team" />
-			</SelectTrigger>
-			<SelectContent>{teamsContent}</SelectContent>
-		</Select>
+		<DropdownMenu>
+			<DropdownMenuTrigger className="w-full" asChild>
+				<Button variant="outline" className="w-full p-4">
+					{currentTeam ? (
+						<div className="flex items-center justify-between gap-2 space-x-2">
+							<Avatar>
+								{currentTeam?.icon ? (
+									<AvatarImage width={32} height={32} src={currentTeamIcon} />
+								) : (
+									<AvatarFallback className="flex items-center justify-center bg-primary font-bold text-primary-foreground">
+										{currentTeam?.name
+											.split(" ")
+											.map((word) => word[0])
+											.join("")
+											.toUpperCase()}
+									</AvatarFallback>
+								)}
+							</Avatar>
+							{currentTeam.name.length > 12
+								? `${currentTeam.name.slice(0, 12)}...`
+								: currentTeam.name}
+						</div>
+					) : (
+						<span className="text-muted-foreground">Select a team</span>
+					)}
+					<ChevronsUpDown className="ml-auto h-4 w-4 text-muted-foreground" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="flex flex-col gap-2">
+				<DropdownMenuLabel className="flex h-[50px] w-[250px] items-center justify-center text-center">
+					{currentTeam ? (
+						<div className="flex items-center justify-center gap-2 space-x-2">
+							<Avatar>
+								{currentTeam?.icon ? (
+									<AvatarImage src={currentTeamIcon} />
+								) : (
+									<AvatarFallback className="flex items-center justify-center bg-primary font-bold text-primary-foreground">
+										{currentTeam?.name
+											.split(" ")
+											.map((word) => word[0])
+											.join("")
+											.toUpperCase()}
+									</AvatarFallback>
+								)}
+							</Avatar>
+							<div className="flex flex-col items-start justify-center">
+								<strong>{currentTeam.name}</strong>
+								<Badge>
+									{session.data?.user.id === currentTeam?.owner_user_id
+										? "Owner"
+										: "Member"}
+								</Badge>
+							</div>
+						</div>
+					) : (
+						<CardTitle className="text-center">Select a team</CardTitle>
+					)}
+				</DropdownMenuLabel>
+				<Button className="w-full" variant="outline">
+					<Settings className="mr-2 h-4 w-4" />
+					Manage Team
+				</Button>
+				<DropdownMenuSeparator />
+				<DropdownMenuRadioGroup
+					value={currentTeam?.uniqueId}
+					onValueChange={onTeamSelect}
+				>
+					{teams?.map((team) => (
+						<DropdownMenuRadioItem key={team.uniqueId} value={team.uniqueId}>
+							{team.name}
+						</DropdownMenuRadioItem>
+					))}
+				</DropdownMenuRadioGroup>
+				<DropdownMenuSeparator />
+				<Button className="w-full" variant="outline">
+					<Plus className="mr-2 h-4 w-4" />
+					Create a new team
+				</Button>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }
 

--- a/src/app/_components/teams/teamSwitchDropdown.tsx
+++ b/src/app/_components/teams/teamSwitchDropdown.tsx
@@ -1,69 +1,3 @@
-// "use client";
-// import type React from "react";
-// import {
-// 	Select,
-// 	SelectContent,
-// 	SelectItem,
-// 	SelectTrigger,
-// 	SelectValue,
-// } from "../ui/select";
-// import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
-// import { useTeams } from "~/app/_lib/teamContext";
-// import { useS3 } from "~/app/_lib/s3Context";
-// import { useParams, useRouter } from "next/navigation";
-
-// function TeamSwitchDropdown({ children, ...props }: React.PropsWithChildren) {
-// 	const params = useParams();
-// 	const router = useRouter();
-
-// 	const teamSlug = params?.teamSlug as string;
-
-// 	const { teams } = useTeams();
-// 	const { icons } = useS3();
-
-// 	if (!teams) {
-// 		return null;
-// 	}
-
-// 	const teamsContent = teams.map((team) => (
-// 		<SelectItem key={team.id} value={team.uniqueId}>
-// 			<Avatar>
-// 				{team.icon ? (
-// 					<AvatarImage
-// 						src={icons?.find((t) => t.key === team.icon)?.url ?? undefined}
-// 					/>
-// 				) : (
-// 					<AvatarFallback>
-// 						{team.name
-// 							.split(" ")
-// 							.map((word) => word[0])
-// 							.join("")
-// 							.toUpperCase()}
-// 					</AvatarFallback>
-// 				)}
-// 			</Avatar>
-// 			{team.name}
-// 		</SelectItem>
-// 	));
-
-// 	const onChange = (value: string) => {
-// 		if (value !== teamSlug) {
-// 			router.push(`/${value}`);
-// 		}
-// 	};
-
-// 	return (
-// 		<Select {...props} value={teamSlug ?? undefined} onValueChange={onChange}>
-// 			<SelectTrigger className="w-full">
-// 				<SelectValue placeholder="Select a team" />
-// 			</SelectTrigger>
-// 			<SelectContent className="w-full">{teamsContent}</SelectContent>
-// 		</Select>
-// 	);
-// }
-
-// export default TeamSwitchDropdown;
-
 "use client";
 import React from "react";
 import { useS3 } from "~/app/_lib/s3Context";
@@ -71,31 +5,41 @@ import { useTeams } from "~/app/_lib/teamContext";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
+	DropdownMenuLabel,
 	DropdownMenuRadioGroup,
 	DropdownMenuRadioItem,
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
 import { Button } from "../ui/button";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
-import { ChevronsUpDown, Plus, Settings } from "lucide-react";
-import { Card, CardHeader, CardTitle } from "../ui/card";
-import { DropdownMenuLabel } from "@radix-ui/react-dropdown-menu";
+import { ChevronsUpDown, Plus, PlusIcon, Settings } from "lucide-react";
+import { CardTitle } from "../ui/card";
 import { useSession } from "next-auth/react";
 import { Badge } from "../ui/badge";
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "../ui/dialog";
+import Hint from "../ui/hint";
+import NewTeamForm from "./newTeamForm";
 
 function TeamSwitchDropdown() {
+	const router = useRouter();
 	const { teams } = useTeams();
 	const { icons } = useS3();
 	const session = useSession();
+	const [DialogOpen, setDialogOpen] = React.useState(false);
 
 	const params = useParams();
 	const teamSlug = params?.teamSlug as string;
 	const currentTeam = teams?.find((team) => team.uniqueId === teamSlug);
 	const currentTeamIcon = icons?.find((t) => t.key === currentTeam?.icon)?.url;
 
-	const onTeamSelect = (value: string) => {};
+	const onTeamSelect = (value: string) => {
+		const selectedTeam = teams?.find((team) => team.uniqueId === value);
+		if (selectedTeam) {
+			router.push(`/${selectedTeam.uniqueId}`);
+		}
+	};
 
 	return (
 		<DropdownMenu>
@@ -167,15 +111,42 @@ function TeamSwitchDropdown() {
 				>
 					{teams?.map((team) => (
 						<DropdownMenuRadioItem key={team.uniqueId} value={team.uniqueId}>
+							<Avatar>
+								{team.icon ? (
+									<AvatarImage src={icons?.find((t) => t.key === team.icon)?.url} />
+								) : (
+									<AvatarFallback className="flex items-center justify-center bg-primary font-bold text-primary-foreground">
+										{team.name
+											.split(" ")
+											.map((word) => word[0])
+											.join("")
+											.toUpperCase()}
+									</AvatarFallback>
+								)}
+							</Avatar>
 							{team.name}
 						</DropdownMenuRadioItem>
 					))}
 				</DropdownMenuRadioGroup>
 				<DropdownMenuSeparator />
-				<Button className="w-full" variant="outline">
-					<Plus className="mr-2 h-4 w-4" />
-					Create a new team
-				</Button>
+				<Dialog open={DialogOpen} onOpenChange={setDialogOpen}>
+					<DialogTrigger asChild>
+						<Button className="w-full" variant="outline">
+							<Plus className="mr-2 h-4 w-4" />
+							Create a new team
+						</Button>
+					</DialogTrigger>
+					<DialogContent>
+						<DialogTitle className="text-center font-semibold text-lg">
+							Let's create a new team!
+							<div className="text-muted-foreground text-sm">
+								You can create a new team to manage your projects and collaborate
+								with others.
+							</div>
+						</DialogTitle>
+						<NewTeamForm setDialogOpen={setDialogOpen} />
+					</DialogContent>
+				</Dialog>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/src/app/_components/teams/teamSwitchDropdown.tsx
+++ b/src/app/_components/teams/teamSwitchDropdown.tsx
@@ -14,12 +14,11 @@ import {
 import { Button } from "../ui/button";
 import { useParams, useRouter } from "next/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
-import { ChevronsUpDown, Plus, PlusIcon, Settings } from "lucide-react";
+import { ChevronsUpDown, Plus, Settings } from "lucide-react";
 import { CardTitle } from "../ui/card";
 import { useSession } from "next-auth/react";
 import { Badge } from "../ui/badge";
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "../ui/dialog";
-import Hint from "../ui/hint";
 import NewTeamForm from "./newTeamForm";
 
 function TeamSwitchDropdown() {

--- a/src/app/_lib/teamContext.tsx
+++ b/src/app/_lib/teamContext.tsx
@@ -32,11 +32,11 @@ export function TeamProvider({ children }: React.PropsWithChildren) {
 }
 
 export function useTeams() {
-    const context = useContext(TeamContext);
+	const context = useContext(TeamContext);
 
-    if (!context) {
-        throw new Error("useTeams must be used within a TeamProvider");
-    }
+	if (!context) {
+		throw new Error("useTeams must be used within a TeamProvider");
+	}
 
-    return context;
+	return context;
 }

--- a/src/app/_lib/utils.ts
+++ b/src/app/_lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+	return twMerge(clsx(inputs));
 }

--- a/src/server/api/routers/team.ts
+++ b/src/server/api/routers/team.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { observable } from "@trpc/server/observable";
 import type { Team } from "@prisma/client";
 
-const teamEvents = new EventEmitter();
+export const teamEvents = new EventEmitter();
 
 export const teamRouter = createTRPCRouter({
 	create: protectedProcedure


### PR DESCRIPTION
## Summary by Sourcery

Revamp the team switcher into a richer dropdown UI with manage and create workflows, integrate session handling, enhance S3 grant generation, improve the database startup script, and tighten input and build configurations.

New Features:
- Replace team selector with a dropdown menu that previews the current team and offers manage and create actions
- Add a dialog-driven form for creating new teams with length validations for names and slugs
- Wrap the dashboard layout in Next-Auth’s SessionProvider for session support
- Introduce an uploadComplete mutation to emit team update events on S3 uploads

Bug Fixes:
- Fix awk delimiter warning when parsing DB_PORT in start-database.sh

Enhancements:
- Extend the S3 grants router to auto-generate and merge missing grants for team icons
- Improve Podman detection and auto-start logic in start-database.sh for better WSL support
- Enforce maximum length rules for team name and slug inputs
- Add pnpm onlyBuiltDependencies configuration to speed up builds

Build:
- Add pnpm onlyBuiltDependencies configuration

Chores:
- Export teamEvents from the team router for reuse
- Apply minor formatting and import cleanup in utility and context files